### PR TITLE
Add missing algorithm include

### DIFF
--- a/overlay/files/third_party/blink/renderer/core/frame/screen.cc
+++ b/overlay/files/third_party/blink/renderer/core/frame/screen.cc
@@ -28,6 +28,8 @@
 
 #include "third_party/blink/renderer/core/frame/screen.h"
 
+#include <algorithm>
+
 #include "base/numerics/safe_conversions.h"
 #include "services/network/public/mojom/permissions_policy/permissions_policy_feature.mojom-blink.h"
 #include "third_party/blink/renderer/core/event_target_names.h"


### PR DESCRIPTION
## Summary
- include `<algorithm>` in `screen.cc` so `std::ranges::all_of` is declared

## Testing
- `g++ -std=c++20 -fsyntax-only overlay/files/third_party/blink/renderer/core/frame/screen.cc` *(fails: third_party/blink/renderer/core/frame/screen.h: No such file or directory)*
- `OS=linux bash overlay/tools/apply_overlay.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c2716c4b08321b21133fbffb66860